### PR TITLE
Fix: Remove transaction wrapper for TRUNCATE operations for Redshift compatibility

### DIFF
--- a/packages/jwt-audit-analytics-writer/src/repositories/clientAssertion.repository.ts
+++ b/packages/jwt-audit-analytics-writer/src/repositories/clientAssertion.repository.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { IMain, ITask } from "pagopa-interop-kpi-commons";
+import { DB, IMain, ITask } from "pagopa-interop-kpi-commons";
 import {
   genericInternalError,
   JwtGeneratedDbTable,
@@ -9,11 +9,12 @@ import { buildColumnSet } from "../utilities/pgHelper.js";
 import { GeneratedTokenAuditDetails } from "../model/domain/models.js";
 import { ClientAssertionMapping } from "../model/db.js";
 
-export function clientAssertionRepository(t: ITask<unknown>) {
+export function clientAssertionRepository(db: DB) {
   const clientAssertionTable = JwtGeneratedDbTable.client_assertion;
 
   return {
     async insert(
+      t: ITask<unknown>,
       pgp: IMain,
       records: GeneratedTokenAuditDetails[]
     ): Promise<void> {
@@ -48,7 +49,7 @@ export function clientAssertionRepository(t: ITask<unknown>) {
       }
     },
 
-    async merge(): Promise<void> {
+    async merge(t: ITask<unknown>): Promise<void> {
       try {
         await t.none(`
             MERGE INTO ${config.dbSchemaName}.${clientAssertionTable} AS target 
@@ -94,7 +95,7 @@ export function clientAssertionRepository(t: ITask<unknown>) {
 
     async clean(): Promise<void> {
       try {
-        await t.none(
+        await db.none(
           `TRUNCATE TABLE ${config.dbSchemaName}.${clientAssertionTable}${config.mergeTableSuffix};`
         );
       } catch (error: unknown) {

--- a/packages/jwt-audit-analytics-writer/src/repositories/generatedToken.repository.ts
+++ b/packages/jwt-audit-analytics-writer/src/repositories/generatedToken.repository.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { IMain, ITask } from "pagopa-interop-kpi-commons";
+import { DB, IMain, ITask } from "pagopa-interop-kpi-commons";
 import {
   genericInternalError,
   JwtGeneratedDbTable,
@@ -9,11 +9,12 @@ import { buildColumnSet } from "../utilities/pgHelper.js";
 import { GeneratedTokenAuditDetails } from "../model/domain/models.js";
 import { GeneratedTokenMapping } from "../model/db.js";
 
-export function generatedTokenRepository(t: ITask<unknown>) {
+export function generatedTokenRepository(db: DB) {
   const generatedTokenTable = JwtGeneratedDbTable.generated_token;
 
   return {
     async insert(
+      t: ITask<unknown>,
       pgp: IMain,
       records: GeneratedTokenAuditDetails[]
     ): Promise<void> {
@@ -56,7 +57,7 @@ export function generatedTokenRepository(t: ITask<unknown>) {
       }
     },
 
-    async merge(): Promise<void> {
+    async merge(t: ITask<unknown>): Promise<void> {
       try {
         await t.none(`
             MERGE INTO ${config.dbSchemaName}.${generatedTokenTable} AS target
@@ -132,7 +133,7 @@ export function generatedTokenRepository(t: ITask<unknown>) {
 
     async clean(): Promise<void> {
       try {
-        await t.none(
+        await db.none(
           `TRUNCATE TABLE ${config.dbSchemaName}.${generatedTokenTable}${config.mergeTableSuffix};`
         );
       } catch (error: unknown) {

--- a/packages/jwt-audit-analytics-writer/src/services/dbService.ts
+++ b/packages/jwt-audit-analytics-writer/src/services/dbService.ts
@@ -16,23 +16,21 @@ export function dbServiceBuilder(
       records: GeneratedTokenAuditDetails[]
     ): Promise<void> {
       await db.tx(async (t) => {
-        await clientAssertionRepo(t).insert(pgp, records);
-        await generatedTokenRepo(t).insert(pgp, records);
+        await clientAssertionRepo(db).insert(t, pgp, records);
+        await generatedTokenRepo(db).insert(t, pgp, records);
       });
     },
 
     async mergeStagingToTarget(): Promise<void> {
       await db.tx(async (t) => {
-        await clientAssertionRepo(t).merge();
-        await generatedTokenRepo(t).merge();
+        await clientAssertionRepo(db).merge(t);
+        await generatedTokenRepo(db).merge(t);
       });
     },
 
     async cleanStaging(): Promise<void> {
-      await db.tx(async (t) => {
-        await clientAssertionRepo(t).clean();
-        await generatedTokenRepo(t).clean();
-      });
+      await clientAssertionRepo(db).clean();
+      await generatedTokenRepo(db).clean();
     },
   };
 }

--- a/packages/jwt-audit-analytics-writer/src/services/jwtAuditService.ts
+++ b/packages/jwt-audit-analytics-writer/src/services/jwtAuditService.ts
@@ -53,10 +53,10 @@ export const jwtAuditServiceBuilder = (
     } catch (error: unknown) {
       if (totalRecordsProcessed > 0) {
         await dbService.cleanStaging();
+        logger.warn(
+          `Error processing file ${s3key}. Performed staging cleanup.`
+        );
       }
-      logger.error(
-        `Error encountered while processing file: ${s3key}. Staging cleanup completed.`
-      );
       throw error;
     }
   },

--- a/packages/jwt-audit-analytics-writer/test/dbService.test.ts
+++ b/packages/jwt-audit-analytics-writer/test/dbService.test.ts
@@ -158,12 +158,14 @@ describe("DB Service tests", () => {
       );
 
       await postgresDB.tx(async (t: ITask<unknown>) => {
-        await clientAssertionRepository(t).insert(
+        await clientAssertionRepository(postgresDB).insert(
+          t,
           postgresDB.$config.pgp,
           records
         );
 
-        await generatedTokenRepository(t).insert(
+        await generatedTokenRepository(postgresDB).insert(
+          t,
           postgresDB.$config.pgp,
           records
         );
@@ -178,13 +180,13 @@ describe("DB Service tests", () => {
 
       await expect(
         postgresDB.tx(async (t: ITask<unknown>) => {
-          const generatedTokenRepoSpy = generatedTokenRepository(t);
+          const generatedTokenRepoSpy = generatedTokenRepository(postgresDB);
           vi.spyOn(generatedTokenRepoSpy, "merge").mockImplementation(() =>
             Promise.reject(mockError)
           );
 
-          await clientAssertionRepository(t).merge();
-          await generatedTokenRepoSpy.merge();
+          await clientAssertionRepository(postgresDB).merge(t);
+          await generatedTokenRepoSpy.merge(t);
         })
       ).rejects.toThrowError(mockError);
 


### PR DESCRIPTION
## Description

The transaction wrapper has been removed from the TRUNCATE operations to ensure compatibility with Redshift. Unlike Postgres which allows TRUNCATE within a transaction, Redshift does not support executing TRUNCATE commands inside a transactional block. This change isolates non-transactional DDL operations (like TRUNCATE) from transactional DML operations (such as INSERT and MERGE). By doing so, the staging cleanup process is executed without errors in Redshift, while transactional safety is preserved for operations that support it.

## Changes Made
- Updated `jwt-audit-analytics-writer` package.

