### PR TITLE
PIN-6452: changed pk to enforce 1:1 relationship between client_assertion and generated_token

### DIFF
--- a/docker/postgres/init-db.sql
+++ b/docker/postgres/init-db.sql
@@ -17,7 +17,8 @@ CREATE TABLE IF NOT EXISTS jwt.generated_token_audit (
     subject VARCHAR(255) NOT NULL,
     not_before TIMESTAMPTZ NOT NULL,
     expiration_time TIMESTAMPTZ NOT NULL,
-    issuer VARCHAR(255) NOT NULL
+    issuer VARCHAR(255) NOT NULL,
+    client_assertion_jwt_id VARCHAR(36) NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS jwt.client_assertion_audit (

--- a/docker/postgres/init-db.sql
+++ b/docker/postgres/init-db.sql
@@ -1,16 +1,5 @@
 CREATE SCHEMA IF NOT EXISTS jwt;
 
-CREATE TABLE IF NOT EXISTS jwt.client_assertion_audit (
-    jwt_id VARCHAR(36) PRIMARY KEY,
-    issued_at TIMESTAMPTZ NOT NULL,
-    algorithm VARCHAR(50) NOT NULL,
-    key_id VARCHAR(255) NOT NULL,
-    issuer VARCHAR(255) NOT NULL,
-    subject VARCHAR(36) NOT NULL,
-    audience VARCHAR(255) NOT NULL,
-    expiration_time TIMESTAMPTZ NOT NULL
-);
-
 CREATE TABLE IF NOT EXISTS jwt.generated_token_audit (
     jwt_id VARCHAR(36) PRIMARY KEY,
     correlation_id VARCHAR(36) NOT NULL,
@@ -28,9 +17,20 @@ CREATE TABLE IF NOT EXISTS jwt.generated_token_audit (
     subject VARCHAR(255) NOT NULL,
     not_before TIMESTAMPTZ NOT NULL,
     expiration_time TIMESTAMPTZ NOT NULL,
+    issuer VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS jwt.client_assertion_audit (
+    jwt_id VARCHAR(36),
+    issued_at TIMESTAMPTZ NOT NULL,
+    algorithm VARCHAR(50) NOT NULL,
+    key_id VARCHAR(255) NOT NULL,
     issuer VARCHAR(255) NOT NULL,
-    client_assertion_jwt_id VARCHAR(36) NOT NULL,
-    CONSTRAINT fk_client_assertion FOREIGN KEY (client_assertion_jwt_id) REFERENCES jwt.client_assertion_audit(jwt_id) ON DELETE CASCADE
+    subject VARCHAR(36) NOT NULL,
+    audience VARCHAR(255) NOT NULL,
+    expiration_time TIMESTAMPTZ NOT NULL,
+    generated_token_jwt_id VARCHAR(36) PRIMARY KEY,
+    CONSTRAINT fk_generated_token FOREIGN KEY (generated_token_jwt_id) REFERENCES jwt.generated_token_audit(jwt_id) ON DELETE CASCADE
 );
 
 CREATE SCHEMA IF NOT EXISTS infra;

--- a/packages/jwt-audit-analytics-writer/src/model/db.ts
+++ b/packages/jwt-audit-analytics-writer/src/model/db.ts
@@ -9,6 +9,7 @@ export interface ClientAssertionSchema {
   subject: string;
   audience: string;
   expiration_time: Date;
+  generated_token_jwt_id: string;
 }
 
 export interface GeneratedTokenSchema {
@@ -29,7 +30,6 @@ export interface GeneratedTokenSchema {
   not_before: Date;
   expiration_time: Date;
   issuer: string;
-  client_assertion_jwt_id: string;
 }
 
 /**

--- a/packages/jwt-audit-analytics-writer/src/model/db.ts
+++ b/packages/jwt-audit-analytics-writer/src/model/db.ts
@@ -30,6 +30,7 @@ export interface GeneratedTokenSchema {
   not_before: Date;
   expiration_time: Date;
   issuer: string;
+  client_assertion_jwt_id: string;
 }
 
 /**

--- a/packages/jwt-audit-analytics-writer/src/repositories/clientAssertion.repository.ts
+++ b/packages/jwt-audit-analytics-writer/src/repositories/clientAssertion.repository.ts
@@ -30,6 +30,7 @@ export function clientAssertionRepository(conn: DBConnection) {
           audience: (record) => record.clientAssertion.audience,
           expiration_time: (record) =>
             new Date(record.clientAssertion.expirationTime),
+          generated_token_jwt_id: (record) => record.jwtId,
         };
 
         const clientAssertionTableName = `${clientAssertionTable}${config.mergeTableSuffix}`;
@@ -54,7 +55,7 @@ export function clientAssertionRepository(conn: DBConnection) {
         await t.none(`
             MERGE INTO ${config.dbSchemaName}.${clientAssertionTable} 
             USING ${clientAssertionTable}${config.mergeTableSuffix} AS source
-              ON ${config.dbSchemaName}.${clientAssertionTable}.jwt_id = source.jwt_id
+              ON ${config.dbSchemaName}.${clientAssertionTable}.generated_token_jwt_id = source.generated_token_jwt_id
             WHEN MATCHED THEN
               UPDATE
                 SET issued_at       = source.issued_at,
@@ -73,7 +74,8 @@ export function clientAssertionRepository(conn: DBConnection) {
                 issuer, 
                 subject, 
                 audience, 
-                expiration_time
+                expiration_time,
+                generated_token_jwt_id
                 )
               VALUES (
                 source.jwt_id, 
@@ -83,7 +85,8 @@ export function clientAssertionRepository(conn: DBConnection) {
                 source.issuer, 
                 source.subject, 
                 source.audience, 
-                source.expiration_time
+                source.expiration_time,
+                source.generated_token_jwt_id
               );
           `);
       } catch (error: unknown) {

--- a/packages/jwt-audit-analytics-writer/src/repositories/generatedToken.repository.ts
+++ b/packages/jwt-audit-analytics-writer/src/repositories/generatedToken.repository.ts
@@ -38,6 +38,7 @@ export function generatedTokenRepository(conn: DBConnection) {
           not_before: (record) => new Date(record.notBefore),
           expiration_time: (record) => new Date(record.expirationTime),
           issuer: (record) => record.issuer,
+          client_assertion_jwt_id: (record) => record.clientAssertion.jwtId,
         };
 
         const tokenAuditTableName = `${generatedTokenTable}${config.mergeTableSuffix}`;
@@ -79,7 +80,8 @@ export function generatedTokenRepository(conn: DBConnection) {
                     subject              = source.subject,
                     not_before           = source.not_before,
                     expiration_time      = source.expiration_time,
-                    issuer               = source.issuer
+                    issuer               = source.issuer,
+                    client_assertion_jwt_id = source.client_assertion_jwt_id
             WHEN NOT MATCHED THEN 
               INSERT (
                 jwt_id,
@@ -98,7 +100,8 @@ export function generatedTokenRepository(conn: DBConnection) {
                 subject,
                 not_before,
                 expiration_time,
-                issuer
+                issuer,
+                client_assertion_jwt_id
               )
               VALUES (
                 source.jwt_id,
@@ -117,7 +120,8 @@ export function generatedTokenRepository(conn: DBConnection) {
                 source.subject,
                 source.not_before,
                 source.expiration_time,
-                source.issuer
+                source.issuer,
+                source.client_assertion_jwt_id
               );
           `);
       } catch (error: unknown) {

--- a/packages/jwt-audit-analytics-writer/src/repositories/generatedToken.repository.ts
+++ b/packages/jwt-audit-analytics-writer/src/repositories/generatedToken.repository.ts
@@ -38,7 +38,6 @@ export function generatedTokenRepository(conn: DBConnection) {
           not_before: (record) => new Date(record.notBefore),
           expiration_time: (record) => new Date(record.expirationTime),
           issuer: (record) => record.issuer,
-          client_assertion_jwt_id: (record) => record.clientAssertion.jwtId,
         };
 
         const tokenAuditTableName = `${generatedTokenTable}${config.mergeTableSuffix}`;
@@ -52,7 +51,7 @@ export function generatedTokenRepository(conn: DBConnection) {
         await t.none(pgp.helpers.insert(records, tokenAuditColumnSet));
       } catch (error: unknown) {
         throw genericInternalError(
-          `Error inserting into generated_client staging table: ${error}`
+          `Error inserting into generated_token staging table: ${error}`
         );
       }
     },
@@ -80,8 +79,7 @@ export function generatedTokenRepository(conn: DBConnection) {
                     subject              = source.subject,
                     not_before           = source.not_before,
                     expiration_time      = source.expiration_time,
-                    issuer               = source.issuer,
-                    client_assertion_jwt_id = source.client_assertion_jwt_id
+                    issuer               = source.issuer
             WHEN NOT MATCHED THEN 
               INSERT (
                 jwt_id,
@@ -100,8 +98,7 @@ export function generatedTokenRepository(conn: DBConnection) {
                 subject,
                 not_before,
                 expiration_time,
-                issuer,
-                client_assertion_jwt_id
+                issuer
               )
               VALUES (
                 source.jwt_id,
@@ -120,13 +117,12 @@ export function generatedTokenRepository(conn: DBConnection) {
                 source.subject,
                 source.not_before,
                 source.expiration_time,
-                source.issuer,
-                source.client_assertion_jwt_id
+                source.issuer
               );
           `);
       } catch (error: unknown) {
         throw genericInternalError(
-          `Error merging staging to target generated_client table: ${error}`
+          `Error merging staging to target generated_token table: ${error}`
         );
       }
     },
@@ -138,7 +134,7 @@ export function generatedTokenRepository(conn: DBConnection) {
         );
       } catch (error: unknown) {
         throw genericInternalError(
-          `Error cleaning staging generated_client table: ${error}`
+          `Error cleaning staging generated_token table: ${error}`
         );
       }
     },

--- a/packages/jwt-audit-analytics-writer/src/services/dbService.ts
+++ b/packages/jwt-audit-analytics-writer/src/services/dbService.ts
@@ -14,21 +14,21 @@ export function dbServiceBuilder(
       records: GeneratedTokenAuditDetails[]
     ): Promise<void> {
       await db.conn.tx(async (t) => {
-        await clientAssertionRepo(db.conn).insert(t, db.pgp, records);
         await generatedTokenRepo(db.conn).insert(t, db.pgp, records);
+        await clientAssertionRepo(db.conn).insert(t, db.pgp, records);
       });
     },
 
     async mergeStagingToTarget(): Promise<void> {
       await db.conn.tx(async (t) => {
-        await clientAssertionRepo(db.conn).merge(t);
         await generatedTokenRepo(db.conn).merge(t);
+        await clientAssertionRepo(db.conn).merge(t);
       });
     },
 
     async cleanStaging(): Promise<void> {
-      await clientAssertionRepo(db.conn).clean();
       await generatedTokenRepo(db.conn).clean();
+      await clientAssertionRepo(db.conn).clean();
     },
   };
 }

--- a/packages/jwt-audit-analytics-writer/src/services/setupDbService.ts
+++ b/packages/jwt-audit-analytics-writer/src/services/setupDbService.ts
@@ -11,20 +11,19 @@ export function setupDbServiceBuilder(conn: DBConnection) {
   return {
     async setupStagingTables(): Promise<void> {
       try {
-        const createClientAssertionTableQuery = `
-          CREATE TEMPORARY TABLE IF NOT EXISTS ${clientAssertionTable}${config.mergeTableSuffix} (
-            LIKE ${config.dbSchemaName}.${clientAssertionTable}
-          );
-        `;
-
         const createGeneratedTokenTableQuery = `
           CREATE TEMPORARY TABLE IF NOT EXISTS ${generatedTokenTable}${config.mergeTableSuffix} (
             LIKE ${config.dbSchemaName}.${generatedTokenTable}
           );
         `;
 
-        await conn.query(createClientAssertionTableQuery);
+        const createClientAssertionTableQuery = `
+          CREATE TEMPORARY TABLE IF NOT EXISTS ${clientAssertionTable}${config.mergeTableSuffix} (
+            LIKE ${config.dbSchemaName}.${clientAssertionTable}
+          );
+        `;
         await conn.query(createGeneratedTokenTableQuery);
+        await conn.query(createClientAssertionTableQuery);
       } catch (error: unknown) {
         throw setupStagingTablesError(error);
       }

--- a/packages/jwt-audit-analytics-writer/test/dbService.test.ts
+++ b/packages/jwt-audit-analytics-writer/test/dbService.test.ts
@@ -64,7 +64,7 @@ describe("DB Service tests", () => {
       expect(clientAssertionStagingCount).toBe(10);
     });
 
-    it("should throw an error if database query fails", async () => {
+    it("should throw an error if database query fails on generated_token table", async () => {
       const mockQueryError =
         "TypeError: Cannot generate an INSERT from an empty array.";
 
@@ -76,19 +76,19 @@ describe("DB Service tests", () => {
 
       await expect(dbService.insertRecordsToStaging([])).rejects.toThrowError(
         genericInternalError(
-          `Error inserting into client_assertion staging table: ${mockQueryError}`
+          `Error inserting into generated_token staging table: ${mockQueryError}`
         )
       );
     });
 
-    it("should throw an error and rollback client_assertion records when generated_token inserts fails", async () => {
+    it("should throw an error and rollback generated_token records when client_assertion inserts fails", async () => {
       const mockQueryError =
         "TypeError: Cannot generate an INSERT from an empty array.";
       const mockError = genericInternalError(
-        `Error inserting into generated_token staging table: ${mockQueryError}`
+        `Error inserting into client_assertion staging table: ${mockQueryError}`
       );
 
-      const mockGeneratedTokenRepository = vi.fn().mockImplementation(() => ({
+      const mockClientAssertionRepository = vi.fn().mockImplementation(() => ({
         insert: vi.fn(() => Promise.reject(mockError)),
         merge: vi.fn(() => Promise.resolve()),
         clean: vi.fn(() => Promise.resolve()),
@@ -99,17 +99,17 @@ describe("DB Service tests", () => {
       const dbService = dbServiceBuilder(
         dbContext,
         clientAssertionRepository,
-        mockGeneratedTokenRepository
+        mockClientAssertionRepository
       );
 
       await expect(
         dbService.insertRecordsToStaging(records)
       ).rejects.toThrowError(mockError);
 
-      const clientAssertionStagingCountAfterRollback =
+      const generatedTokenStagingCountAfterRollback =
         await getStagingTableCount(conn, clientAssertionStagingTableName);
 
-      expect(clientAssertionStagingCountAfterRollback).toBe(0);
+      expect(generatedTokenStagingCountAfterRollback).toBe(0);
     });
   });
 
@@ -140,42 +140,41 @@ describe("DB Service tests", () => {
       expect(generatedTokenTargetCountAfterMerge).toBe(10);
     });
 
-    it("should throw an error and rollback merged client_assertion records when generated_token merge fails", async () => {
+    it("should throw an error and rollback merged generated_token records when client_assertion merge fails", async () => {
       const records: GeneratedTokenAuditDetails[] = getMockJwtAudits(10);
       const mockQueryError = "Generic merge error";
       const mockError = genericInternalError(
-        `Error merging staging to target generated_client table: ${mockQueryError}`
+        `Error merging staging to target client_assertion table: ${mockQueryError}`
       );
 
       await conn.tx(async (t: ITask<unknown>) => {
-        await clientAssertionRepository(conn).insert(t, pgp, records);
-
         await generatedTokenRepository(conn).insert(t, pgp, records);
+        await clientAssertionRepository(conn).insert(t, pgp, records);
       });
 
-      const clientAssertionStagingCountAfterInsert = await getStagingTableCount(
+      const generatedTokenStagingCountAfterInsert = await getStagingTableCount(
         conn,
-        clientAssertionStagingTableName
+        generatedTokenStagingTableName
       );
-      expect(clientAssertionStagingCountAfterInsert).toBe(10);
+      expect(generatedTokenStagingCountAfterInsert).toBe(10);
 
       await expect(
         conn.tx(async (t: ITask<unknown>) => {
-          const generatedTokenRepoSpy = generatedTokenRepository(conn);
-          vi.spyOn(generatedTokenRepoSpy, "merge").mockImplementation(() =>
+          const clientAssertionRepoSpy = clientAssertionRepository(conn);
+          vi.spyOn(clientAssertionRepoSpy, "merge").mockImplementation(() =>
             Promise.reject(mockError)
           );
 
-          await clientAssertionRepository(conn).merge(t);
-          await generatedTokenRepoSpy.merge(t);
+          await generatedTokenRepository(conn).merge(t);
+          await clientAssertionRepoSpy.merge(t);
         })
       ).rejects.toThrowError(mockError);
 
-      const clientAssertionCountAfterRollback = await getTargetTableCount(
+      const generatedTokenCountAfterRollback = await getTargetTableCount(
         conn,
-        clientAssertionTargetTableName
+        generatedTokenTargetTableName
       );
-      expect(clientAssertionCountAfterRollback).toBe(0);
+      expect(generatedTokenCountAfterRollback).toBe(0);
     });
   });
 

--- a/packages/jwt-audit-analytics-writer/test/utils.ts
+++ b/packages/jwt-audit-analytics-writer/test/utils.ts
@@ -47,8 +47,8 @@ await retryConnection(
   postgresDB,
   dbContext,
   config,
-  async () => {
-    // Intentionally left blank to prevent table creation during setupStagingTables tests
+  async (db) => {
+    await setupDbServiceBuilder(db.conn).setupStagingTables();
   },
   genericLogger
 );

--- a/packages/jwt-audit-analytics-writer/test/utils.ts
+++ b/packages/jwt-audit-analytics-writer/test/utils.ts
@@ -47,8 +47,8 @@ await retryConnection(
   postgresDB,
   dbContext,
   config,
-  async (db) => {
-    await setupDbServiceBuilder(db.conn).setupStagingTables();
+  async () => {
+    // Intentionally left blank to prevent table creation during setupStagingTables tests
   },
   genericLogger
 );
@@ -206,11 +206,11 @@ export async function truncateTables(
   await db.none(
     `TRUNCATE TABLE ${schema}.${JwtDbTable.client_assertion}${
       stagingTableSuffix ?? ""
-    } CASCADE;`
+    };`
   );
   await db.none(
     `TRUNCATE TABLE ${schema}.${JwtDbTable.generated_token}${
       stagingTableSuffix ?? ""
-    };`
+    } CASCADE;`
   );
 }


### PR DESCRIPTION
## Description

This pull request modifies the database schema and models to enforce a one-to-one relationship between the client_assertion and generated_token tables. Specifically, the primary key of the client_assertion table has been updated to use the jwt_id from the generated_token table, ensuring a direct and unique association between each client assertion and its corresponding generated token.

## Changes Made
- Updated `jwt-audit-analytics-writer` package.