### PR TITLE
PIN-6465: Skip processing not relevant events on SQS queue

### DIFF
--- a/packages/commons/src/sqs/messageValidation.ts
+++ b/packages/commons/src/sqs/messageValidation.ts
@@ -1,0 +1,47 @@
+import { sqsMessageNotValid } from "pagopa-interop-kpi-models";
+import { Message } from "./sqs.js";
+import { genericLogger } from "../index.js";
+
+type WhitelistedEvent =
+  | "ObjectCreated"
+  | "ObjectCreated:Put"
+  | "ObjectCreated:Post"
+  | "ObjectCreated:Copy";
+
+const validEvents: WhitelistedEvent[] = [
+  "ObjectCreated",
+  "ObjectCreated:Put",
+  "ObjectCreated:Post",
+  "ObjectCreated:Copy",
+];
+
+type EventValidation = "ValidEvent" | "InvalidEvent";
+
+export const validateSqsMessage = (message: Message): EventValidation => {
+  if (!message.Body) {
+    throw new Error("Message body is undefined");
+  }
+
+  try {
+    const body = JSON.parse(message.Body);
+
+    if (body.Event === "s3:TestEvent") {
+      genericLogger.warn(`Skipping event - ${body.Event}`);
+      return "InvalidEvent";
+    }
+
+    if (Array.isArray(body.Records)) {
+      const record = body.Records[0];
+      const eventName = record?.eventName;
+
+      if (eventName && validEvents.includes(eventName)) {
+        return "ValidEvent";
+      } else {
+        genericLogger.warn(`Skipping event - ${eventName}`);
+      }
+    }
+    return "InvalidEvent";
+  } catch (error) {
+    throw sqsMessageNotValid(`${error}`);
+  }
+};

--- a/packages/commons/src/sqs/messageValidation.ts
+++ b/packages/commons/src/sqs/messageValidation.ts
@@ -1,6 +1,6 @@
 import { sqsMessageNotValid } from "pagopa-interop-kpi-models";
-import { Message } from "./sqs.js";
 import { genericLogger } from "../index.js";
+import { Message } from "./sqs.js";
 
 type WhitelistedEvent =
   | "ObjectCreated"

--- a/packages/commons/src/sqs/sqs.ts
+++ b/packages/commons/src/sqs/sqs.ts
@@ -8,10 +8,10 @@ import {
   SQSClientConfig,
 } from "@aws-sdk/client-sqs";
 import { InternalError } from "pagopa-interop-kpi-models";
+import { match } from "ts-pattern";
 import { genericLogger } from "../logging/index.js";
 import { ConsumerConfig } from "../config/consumerConfig.js";
 import { validateSqsMessage } from "./messageValidation.js";
-import { match } from "ts-pattern";
 
 const serializeError = (error: unknown): string => {
   try {

--- a/packages/commons/src/sqs/sqs.ts
+++ b/packages/commons/src/sqs/sqs.ts
@@ -10,6 +10,8 @@ import {
 import { InternalError } from "pagopa-interop-kpi-models";
 import { genericLogger } from "../logging/index.js";
 import { ConsumerConfig } from "../config/consumerConfig.js";
+import { validateSqsMessage } from "./messageValidation.js";
+import { match } from "ts-pattern";
 
 const serializeError = (error: unknown): string => {
   try {
@@ -52,12 +54,25 @@ const processQueue = async (
         }
 
         try {
-          await consumerHandler(message);
-          await deleteMessage(
-            sqsClient,
-            config.queueUrl,
-            message.ReceiptHandle
-          );
+          const result = validateSqsMessage(message);
+          if (!message.ReceiptHandle) {
+            throw new Error(
+              `ReceiptHandle not found in Message: ${JSON.stringify(message)}`
+            );
+          }
+          const receiptHandle = message.ReceiptHandle;
+
+          await match(result)
+            .with("InvalidEvent", async () => {
+              genericLogger.info(`Deleting message - invalid event detected.`);
+              await deleteMessage(sqsClient, config.queueUrl, receiptHandle);
+            })
+            .with("ValidEvent", async () => {
+              genericLogger.info("Processing valid event.");
+              await consumerHandler(message);
+              await deleteMessage(sqsClient, config.queueUrl, receiptHandle);
+            })
+            .exhaustive();
         } catch (e) {
           genericLogger.error(
             `Unexpected error consuming message: ${JSON.stringify(

--- a/packages/commons/src/sqs/sqs.ts
+++ b/packages/commons/src/sqs/sqs.ts
@@ -64,11 +64,9 @@ const processQueue = async (
 
           await match(result)
             .with("InvalidEvent", async () => {
-              genericLogger.info(`Deleting message - invalid event detected.`);
               await deleteMessage(sqsClient, config.queueUrl, receiptHandle);
             })
             .with("ValidEvent", async () => {
-              genericLogger.info("Processing valid event.");
               await consumerHandler(message);
               await deleteMessage(sqsClient, config.queueUrl, receiptHandle);
             })

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -18,6 +18,7 @@ const errorCodes = {
   kafkaMissingMessagesValue: "KAFKA_MISSING_MESSAGES_VALUE",
   kafkaMessageProcessError: "KAFKA_MESSAGE_PROCESS_ERROR",
   setupStagingTablesError: "SETUP_STAGING_TABLES_ERROR",
+  sqsMessageNotValid: "SQS_MESSAGE_NOT_VALID_EROR",
 } as const;
 
 export type CommonErrorCodes = keyof typeof errorCodes;
@@ -88,5 +89,14 @@ export function setupStagingTablesError(
   return new InternalError({
     detail: `Database error occurred while setting up staging tables. ${detail}`,
     code: "setupStagingTablesError",
+  });
+}
+
+export function sqsMessageNotValid(
+  details: string
+): InternalError<CommonErrorCodes> {
+  return new InternalError({
+    code: "sqsMessageNotValid",
+    detail: details,
   });
 }

--- a/packages/models/src/errors.ts
+++ b/packages/models/src/errors.ts
@@ -18,7 +18,7 @@ const errorCodes = {
   kafkaMissingMessagesValue: "KAFKA_MISSING_MESSAGES_VALUE",
   kafkaMessageProcessError: "KAFKA_MESSAGE_PROCESS_ERROR",
   setupStagingTablesError: "SETUP_STAGING_TABLES_ERROR",
-  sqsMessageNotValid: "SQS_MESSAGE_NOT_VALID_EROR",
+  sqsMessageNotValid: "SQS_MESSAGE_NOT_VALID_ERROR",
 } as const;
 
 export type CommonErrorCodes = keyof typeof errorCodes;


### PR DESCRIPTION
This PR checks SQS events by validating them against a whitelist.

- Skips `s3:TestEvent` entirely.
- For s3EventNotification, only `ObjectCreated` events are considered valid.

```
type WhitelistedEvent =
  | "ObjectCreated"
  | "ObjectCreated:Put"
  | "ObjectCreated:Post"
  | "ObjectCreated:Copy";
 ``` 