### PR TITLE
PIN-6509: group application audits by date from timestamp application-audit-archiver

### DIFF
--- a/packages/alb-logs-analytics-writer/src/model/db.ts
+++ b/packages/alb-logs-analytics-writer/src/model/db.ts
@@ -1,38 +1,46 @@
+import { z } from "zod";
 import { LoadBalancerLog } from "./load-balancer-log.js";
 
-export interface LoadBalancerLogSchema {
-  trace_id: string;
-  type: string;
-  time: string;
-  elb: string;
-  client: string;
-  target?: string;
-  request_processing_time: string;
-  target_processing_time: string;
-  response_processing_time: string;
-  elb_status_code: string;
-  target_status_code?: string;
-  received_bytes: string;
-  sent_bytes: string;
-  request: string;
-  user_agent: string;
-  ssl_cipher?: string;
-  ssl_protocol?: string;
-  target_group_arn?: string;
-  domain_name?: string;
-  chosen_cert_arn?: string;
-  matched_rule_priority: string;
-  request_creation_time: string;
-  actions_executed: string;
-  redirect_url?: string;
-  error_reason?: string;
-  target_port_list?: string;
-  target_status_code_list?: string;
-  classification?: string;
-  classification_reason?: string;
-  conn_trace_id?: string;
-}
+export const LoadBalancerLogSchema = z.object({
+  trace_id: z.string(),
+  type: z.string(),
+  time: z.string(),
+  elb: z.string(),
+  client: z.string(),
+  target: z.string().optional(),
+  request_processing_time: z.string(),
+  target_processing_time: z.string(),
+  response_processing_time: z.string(),
+  elb_status_code: z.string(),
+  target_status_code: z.string().optional(),
+  received_bytes: z.string(),
+  sent_bytes: z.string(),
+  request: z.string(),
+  user_agent: z.string(),
+  ssl_cipher: z.string().optional(),
+  ssl_protocol: z.string().optional(),
+  target_group_arn: z.string().optional(),
+  domain_name: z.string().optional(),
+  chosen_cert_arn: z.string().optional(),
+  matched_rule_priority: z.string(),
+  request_creation_time: z.string(),
+  actions_executed: z.string(),
+  redirect_url: z.string().optional(),
+  error_reason: z.string().optional(),
+  target_port_list: z.string().optional(),
+  target_status_code_list: z.string().optional(),
+  classification: z.string().optional(),
+  classification_reason: z.string().optional(),
+  conn_trace_id: z.string().optional(),
+});
+export type LoadBalancerLogSchema = z.infer<typeof LoadBalancerLogSchema>;
 
+/**
+ * LoadBalancerLogMapping is a type alias that defines a mapping interface to convert
+ * a LoadBalancerLog record into a shape that conforms to LoadBalancerLogSchema.
+ * It ensures that the output of each mapping function exactly matches the expected type
+ * for the corresponding column defined in LoadBalancerLogSchema.
+ */
 export type LoadBalancerLogMapping = {
   [K in keyof LoadBalancerLogSchema]: (
     record: LoadBalancerLog

--- a/packages/alb-logs-analytics-writer/src/repositories/loadBalancerLog.repository.ts
+++ b/packages/alb-logs-analytics-writer/src/repositories/loadBalancerLog.repository.ts
@@ -68,14 +68,14 @@ export function loadBalancerLogRepository(conn: DBConnection) {
 
     async merge(): Promise<void> {
       try {
-        const clientAssertionMergeQuery = generateMergeQuery(
+        const loadBalancerMergeQuery = generateMergeQuery(
           LoadBalancerLogSchema,
           config.dbSchemaName,
           loadBalancerTable,
           config.mergeTableSuffix,
           "trace_id"
         );
-        await conn.none(clientAssertionMergeQuery);
+        await conn.none(loadBalancerMergeQuery);
       } catch (error: unknown) {
         throw genericInternalError(
           `Error merging staging to target ${loadBalancerTable} table: ${error}`

--- a/packages/alb-logs-analytics-writer/src/repositories/loadBalancerLog.repository.ts
+++ b/packages/alb-logs-analytics-writer/src/repositories/loadBalancerLog.repository.ts
@@ -3,6 +3,7 @@ import {
   DBConnection,
   IMain,
   buildColumnSet,
+  generateMergeQuery,
 } from "pagopa-interop-kpi-commons";
 import {
   LoadBalancerLogTable,
@@ -10,10 +11,12 @@ import {
 } from "pagopa-interop-kpi-models";
 import { config } from "../config/config.js";
 import { LoadBalancerLog } from "../model/load-balancer-log.js";
-import { LoadBalancerLogMapping } from "../model/db.js";
+import { LoadBalancerLogMapping, LoadBalancerLogSchema } from "../model/db.js";
 
 export function loadBalancerLogRepository(conn: DBConnection) {
   const loadBalancerTable = LoadBalancerLogTable.logs;
+  const loadBalancerStagingTable = `${loadBalancerTable}${config.mergeTableSuffix}`;
+
   return {
     async insert(pgp: IMain, records: LoadBalancerLog[]): Promise<void> {
       try {
@@ -50,138 +53,42 @@ export function loadBalancerLogRepository(conn: DBConnection) {
           conn_trace_id: (record) => record.conn_trace_id,
         };
 
-        const logTableName = `${loadBalancerTable}${config.mergeTableSuffix}`;
         const logColumnSet = buildColumnSet<LoadBalancerLog>(
           pgp,
           logMapping,
-          logTableName
+          loadBalancerStagingTable
         );
         await conn.none(pgp.helpers.insert(records, logColumnSet));
       } catch (error: unknown) {
         throw genericInternalError(
-          `Error inserting into alb_logs_audit staging table: ${error}`
+          `Error inserting into ${loadBalancerStagingTable} staging table: ${error}`
         );
       }
     },
 
     async merge(): Promise<void> {
       try {
-        await conn.none(`
-        MERGE INTO ${config.dbSchemaName}.${loadBalancerTable}
-        USING ${loadBalancerTable}${config.mergeTableSuffix} AS source
-          ON ${config.dbSchemaName}.${loadBalancerTable}.trace_id = source.trace_id
-        WHEN MATCHED THEN
-          UPDATE SET
-            type = source.type,
-            time = source.time,
-            elb = source.elb,
-            client = source.client,
-            target = source.target,
-            request_processing_time = source.request_processing_time,
-            target_processing_time = source.target_processing_time,
-            response_processing_time = source.response_processing_time,
-            elb_status_code = source.elb_status_code,
-            target_status_code = source.target_status_code,
-            received_bytes = source.received_bytes,
-            sent_bytes = source.sent_bytes,
-            request = source.request,
-            user_agent = source.user_agent,
-            ssl_cipher = source.ssl_cipher,
-            ssl_protocol = source.ssl_protocol,
-            target_group_arn = source.target_group_arn,
-            domain_name = source.domain_name,
-            chosen_cert_arn = source.chosen_cert_arn,
-            matched_rule_priority = source.matched_rule_priority,
-            request_creation_time = source.request_creation_time,
-            actions_executed = source.actions_executed,
-            redirect_url = source.redirect_url,
-            error_reason = source.error_reason,
-            target_port_list = source.target_port_list,
-            target_status_code_list = source.target_status_code_list,
-            classification = source.classification,
-            classification_reason = source.classification_reason,
-            conn_trace_id = source.conn_trace_id
-        WHEN NOT MATCHED THEN
-          INSERT (
-            type,
-            time,
-            elb,
-            client,
-            target,
-            request_processing_time,
-            target_processing_time,
-            response_processing_time,
-            elb_status_code,
-            target_status_code,
-            received_bytes,
-            sent_bytes,
-            request,
-            user_agent,
-            ssl_cipher,
-            ssl_protocol,
-            target_group_arn,
-            trace_id,
-            domain_name,
-            chosen_cert_arn,
-            matched_rule_priority,
-            request_creation_time,
-            actions_executed,
-            redirect_url,
-            error_reason,
-            target_port_list,
-            target_status_code_list,
-            classification,
-            classification_reason,
-            conn_trace_id
-          )
-          VALUES (
-            source.type,
-            source.time,
-            source.elb,
-            source.client,
-            source.target,
-            source.request_processing_time,
-            source.target_processing_time,
-            source.response_processing_time,
-            source.elb_status_code,
-            source.target_status_code,
-            source.received_bytes,
-            source.sent_bytes,
-            source.request,
-            source.user_agent,
-            source.ssl_cipher,
-            source.ssl_protocol,
-            source.target_group_arn,
-            source.trace_id,
-            source.domain_name,
-            source.chosen_cert_arn,
-            source.matched_rule_priority,
-            source.request_creation_time,
-            source.actions_executed,
-            source.redirect_url,
-            source.error_reason,
-            source.target_port_list,
-            source.target_status_code_list,
-            source.classification,
-            source.classification_reason,
-            source.conn_trace_id
-          );        
-        `);
+        const clientAssertionMergeQuery = generateMergeQuery(
+          LoadBalancerLogSchema,
+          config.dbSchemaName,
+          loadBalancerTable,
+          config.mergeTableSuffix,
+          "trace_id"
+        );
+        await conn.none(clientAssertionMergeQuery);
       } catch (error: unknown) {
         throw genericInternalError(
-          `Error merging staging to target alb_logs_audit table: ${error}`
+          `Error merging staging to target ${loadBalancerTable} table: ${error}`
         );
       }
     },
 
     async clean(): Promise<void> {
       try {
-        await conn.none(
-          `TRUNCATE TABLE ${loadBalancerTable}${config.mergeTableSuffix};`
-        );
+        await conn.none(`TRUNCATE TABLE ${loadBalancerStagingTable};`);
       } catch (error: unknown) {
         throw genericInternalError(
-          `Error cleaning staging alb_logs_audit table: ${error}`
+          `Error cleaning staging ${loadBalancerStagingTable} table: ${error}`
         );
       }
     },

--- a/packages/alb-logs-analytics-writer/src/services/albLogsAuditService.ts
+++ b/packages/alb-logs-analytics-writer/src/services/albLogsAuditService.ts
@@ -53,12 +53,16 @@ export const albLogsAuditServiceBuilder = (
         return;
       }
 
-      logger.info(`Staging records insertion completed for file: ${s3key}`);
+      logger.info(
+        `Staging insertion completed with ${totalRecordsProcessed} records processed for file: ${s3key}.`
+      );
 
       await dbService.mergeStagingToTarget();
+
       logger.info(`Staging data merged into target tables for file: ${s3key}`);
 
       await dbService.cleanStaging();
+
       logger.info(`Staging cleanup completed for file: ${s3key}`);
     } catch (error) {
       if (totalRecordsProcessed !== 0) {

--- a/packages/alb-logs-analytics-writer/test/dbService.test.ts
+++ b/packages/alb-logs-analytics-writer/test/dbService.test.ts
@@ -26,11 +26,11 @@ import {
 
 describe("DB Service Tests for ALB Logs", () => {
   const temporaryDbSchemaName = "pg_temp";
-  const stagingTableName = `${LoadBalancerLogTable.logs}${config.mergeTableSuffix}`;
-  const targetTableName = LoadBalancerLogTable.logs;
+  const stagingTable = `${LoadBalancerLogTable.logs}${config.mergeTableSuffix}`;
+  const targetTable = LoadBalancerLogTable.logs;
 
   beforeAll(async () => {
-    await setupDbService.setupStagingTables([targetTableName]);
+    await setupDbService.setupStagingTables([targetTable]);
   });
 
   afterAll(async () => {
@@ -54,7 +54,7 @@ describe("DB Service Tests for ALB Logs", () => {
       await dbService.insertRecordsToStaging(records);
       const stagingCount = await getStagingTableCount(
         dbContext.conn,
-        stagingTableName
+        stagingTable
       );
 
       expect(stagingCount).toBe(5);
@@ -67,7 +67,7 @@ describe("DB Service Tests for ALB Logs", () => {
 
       await expect(dbService.insertRecordsToStaging([])).rejects.toThrowError(
         genericInternalError(
-          `Error inserting into alb_logs_audit staging table: ${mockQueryError}`
+          `Error inserting into ${stagingTable} staging table: ${mockQueryError}`
         )
       );
     });
@@ -83,7 +83,7 @@ describe("DB Service Tests for ALB Logs", () => {
 
       const targetCount = await getTargetTableCount(
         dbContext.conn,
-        targetTableName
+        targetTable
       );
       expect(targetCount).toBe(5);
     });
@@ -102,7 +102,7 @@ describe("DB Service Tests for ALB Logs", () => {
 
       const stagingCountAfterClean = await getStagingTableCount(
         dbContext.conn,
-        stagingTableName
+        stagingTable
       );
       expect(stagingCountAfterClean).toBe(0);
     });

--- a/packages/application-audit-archiver/src/handler/messagesHandler.ts
+++ b/packages/application-audit-archiver/src/handler/messagesHandler.ts
@@ -1,20 +1,14 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
-/* eslint-disable functional/immutable-data */
 import { KafkaMessage } from "kafkajs";
 import {
   FileManager,
   Logger,
-  decodeKafkaMessage,
   formatTimehhmmss,
 } from "pagopa-interop-kpi-commons";
-import {
-  ApplicationAuditEvent,
-  generateId,
-  genericInternalError,
-} from "pagopa-interop-kpi-models";
+import { generateId, genericInternalError } from "pagopa-interop-kpi-models";
 import { config } from "../config/config.js";
 import { compressJson } from "../utilities/compression.js";
+import { groupMessagesByDate } from "../utilities/groupMessagesByDate.js";
 
 export async function handleMessages(
   messages: KafkaMessage[],
@@ -22,23 +16,9 @@ export async function handleMessages(
   logger: Logger
 ) {
   try {
-    const grouped: Record<string, ApplicationAuditEvent[]> = {};
+    const groupedMessages = groupMessagesByDate(messages);
 
-    for (const message of messages) {
-      const item = decodeKafkaMessage(message, ApplicationAuditEvent);
-      const date = new Date(item.timestamp);
-      const year = date.getUTCFullYear();
-      const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-      const day = String(date.getUTCDate()).padStart(2, "0");
-
-      const key = `${year}-${month}-${day}`;
-      if (!grouped[key]) {
-        grouped[key] = [];
-      }
-      grouped[key].push(item);
-    }
-
-    for (const [dateKey, groupMessages] of Object.entries(grouped)) {
+    for (const [dateKey, groupMessages] of Object.entries(groupedMessages)) {
       const [year, month, day] = dateKey.split("-");
       const jsonString = JSON.stringify(groupMessages);
       const compressedBuffer = await compressJson(jsonString);

--- a/packages/application-audit-archiver/src/handler/messagesHandler.ts
+++ b/packages/application-audit-archiver/src/handler/messagesHandler.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable functional/immutable-data */
 import { KafkaMessage } from "kafkajs";
 import {
   FileManager,
@@ -20,30 +22,40 @@ export async function handleMessages(
   logger: Logger
 ) {
   try {
-    const batch = messages.map((message) =>
-      decodeKafkaMessage(message, ApplicationAuditEvent)
-    );
+    const grouped: Record<string, ApplicationAuditEvent[]> = {};
 
-    const jsonString = JSON.stringify(batch);
-    const compressedBuffer = await compressJson(jsonString);
+    for (const message of messages) {
+      const item = decodeKafkaMessage(message, ApplicationAuditEvent);
+      const date = new Date(item.timestamp);
+      const year = date.getUTCFullYear();
+      const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+      const day = String(date.getUTCDate()).padStart(2, "0");
 
-    const date = new Date();
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-    const time = formatTimehhmmss(date);
+      const key = `${year}-${month}-${day}`;
+      if (!grouped[key]) {
+        grouped[key] = [];
+      }
+      grouped[key].push(item);
+    }
 
-    const fileName = `${year}${month}${day}_${time}_${generateId()}.json.gz`;
-    const filePath = `year=${year}/month=${month}/day=${day}`;
+    for (const [dateKey, groupMessages] of Object.entries(grouped)) {
+      const [year, month, day] = dateKey.split("-");
+      const jsonString = JSON.stringify(groupMessages);
+      const compressedBuffer = await compressJson(jsonString);
 
-    const s3File = {
-      bucket: config.s3BucketName,
-      path: filePath,
-      name: fileName,
-      content: compressedBuffer,
-    };
+      const time = formatTimehhmmss(new Date());
+      const fileName = `${year}${month}${day}_${time}_${generateId()}.json.gz`;
+      const filePath = `year=${year}/month=${month}/day=${day}`;
 
-    await fileManager.storeBytes(s3File, logger);
+      const s3File = {
+        bucket: config.s3BucketName,
+        path: filePath,
+        name: fileName,
+        content: compressedBuffer,
+      };
+
+      await fileManager.storeBytes(s3File, logger);
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : "generic error";
     throw genericInternalError(`Write operation failed - ${message}`);

--- a/packages/application-audit-archiver/src/handler/messagesHandler.ts
+++ b/packages/application-audit-archiver/src/handler/messagesHandler.ts
@@ -18,7 +18,7 @@ export async function handleMessages(
   try {
     const groupedMessages = groupMessagesByDate(messages);
 
-    for (const [dateKey, groupMessages] of Object.entries(groupedMessages)) {
+    for (const [dateKey, groupMessages] of groupedMessages.entries()) {
       const [year, month, day] = dateKey.split("-");
       const jsonString = JSON.stringify(groupMessages);
       const compressedBuffer = await compressJson(jsonString);

--- a/packages/application-audit-archiver/src/utilities/groupMessagesByDate.ts
+++ b/packages/application-audit-archiver/src/utilities/groupMessagesByDate.ts
@@ -1,0 +1,32 @@
+/* eslint-disable functional/immutable-data */
+import { KafkaMessage } from "kafkajs";
+import { decodeKafkaMessage } from "pagopa-interop-kpi-commons";
+import { ApplicationAuditEvent } from "pagopa-interop-kpi-models";
+
+/**
+ * Groups Kafka messages by UTC date (YYYY-MM-DD) extracted from the decoded message
+ *
+ * Each message is decoded using `decodeKafkaMessage`, and its timestamp is used
+ * to build a grouping key in the format `YYYY-MM-DD`.
+ *
+ * @param messages - An array of KafkaMessage objects to group
+ * @returns A record where each key is a date string (YYYY-MM-DD) and the value is an array of ApplicationAuditEvent
+ */
+export function groupMessagesByDate(
+  messages: KafkaMessage[]
+): Record<string, ApplicationAuditEvent[]> {
+  return messages.reduce<Record<string, ApplicationAuditEvent[]>>(
+    (acc, message) => {
+      const item = decodeKafkaMessage(message, ApplicationAuditEvent);
+      const date = new Date(item.timestamp);
+      const year = date.getUTCFullYear();
+      const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+      const day = String(date.getUTCDate()).padStart(2, "0");
+
+      const key = `${year}-${month}-${day}`;
+      acc[key] = [...(acc[key] ?? []), item];
+      return acc;
+    },
+    {}
+  );
+}

--- a/packages/application-audit-archiver/src/utilities/groupMessagesByDate.ts
+++ b/packages/application-audit-archiver/src/utilities/groupMessagesByDate.ts
@@ -1,4 +1,3 @@
-/* eslint-disable functional/immutable-data */
 import { KafkaMessage } from "kafkajs";
 import { decodeKafkaMessage } from "pagopa-interop-kpi-commons";
 import { ApplicationAuditEvent } from "pagopa-interop-kpi-models";

--- a/packages/application-audit-archiver/src/utilities/groupMessagesByDate.ts
+++ b/packages/application-audit-archiver/src/utilities/groupMessagesByDate.ts
@@ -4,29 +4,27 @@ import { decodeKafkaMessage } from "pagopa-interop-kpi-commons";
 import { ApplicationAuditEvent } from "pagopa-interop-kpi-models";
 
 /**
- * Groups Kafka messages by UTC date (YYYY-MM-DD) extracted from the decoded message
+ * Groups Kafka messages by UTC date (YYYY-MM-DD)
  *
- * Each message is decoded using `decodeKafkaMessage`, and its timestamp is used
- * to build a grouping key in the format `YYYY-MM-DD`.
- *
- * @param messages - An array of KafkaMessage objects to group
- * @returns A record where each key is a date string (YYYY-MM-DD) and the value is an array of ApplicationAuditEvent
+ * @param messages - Array of KafkaMessage objects to group
+ * @returns A Map where each key is a date string (YYYY-MM-DD) and the value is an array of ApplicationAuditEvent
  */
 export function groupMessagesByDate(
   messages: KafkaMessage[]
-): Record<string, ApplicationAuditEvent[]> {
-  return messages.reduce<Record<string, ApplicationAuditEvent[]>>(
-    (acc, message) => {
-      const item = decodeKafkaMessage(message, ApplicationAuditEvent);
-      const date = new Date(item.timestamp);
-      const year = date.getUTCFullYear();
-      const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-      const day = String(date.getUTCDate()).padStart(2, "0");
+): Map<string, ApplicationAuditEvent[]> {
+  const grouped = new Map<string, ApplicationAuditEvent[]>();
 
-      const key = `${year}-${month}-${day}`;
-      acc[key] = [...(acc[key] ?? []), item];
-      return acc;
-    },
-    {}
-  );
+  for (const message of messages) {
+    const event = decodeKafkaMessage(message, ApplicationAuditEvent);
+    const date = new Date(event.timestamp);
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(date.getUTCDate()).padStart(2, "0");
+    const key = `${year}-${month}-${day}`;
+
+    const existing = grouped.get(key) ?? [];
+    grouped.set(key, [...existing, event]);
+  }
+
+  return grouped;
 }

--- a/packages/application-audit-archiver/test/messageHandler.test.ts
+++ b/packages/application-audit-archiver/test/messageHandler.test.ts
@@ -10,7 +10,7 @@ import { compressJson } from "../src/utilities/compression.js";
 import { handleMessages } from "../src/handler/messagesHandler.js";
 import {
   fileManager,
-  validKafkaMessage,
+  getValidKafkaMessage,
   invalidKafkaMessage,
   validAuditEvent,
 } from "./utils.js";
@@ -29,6 +29,7 @@ describe("handleMessages", () => {
     await pipelineAsync(Readable.from(compressedBuffer), gunzip);
     expect(decompressed).toBe(jsonString);
   });
+
   it("should process a single valid message and store on s3bucket with valid name", async () => {
     const mockStoreBytes = vi.fn().mockResolvedValue("mocked-s3-key");
     fileManager.storeBytes = mockStoreBytes;
@@ -37,7 +38,11 @@ describe("handleMessages", () => {
     vi.useFakeTimers();
     vi.setSystemTime(fakeDate);
 
-    await handleMessages([validKafkaMessage], fileManager, genericLogger);
+    await handleMessages(
+      [getValidKafkaMessage(validAuditEvent)],
+      fileManager,
+      genericLogger
+    );
 
     const s3File = mockStoreBytes.mock.calls[0][0];
     const year = fakeDate.getFullYear();
@@ -60,7 +65,7 @@ describe("handleMessages", () => {
 
     await handleMessages([], fileManager, genericLogger);
 
-    expect(mockStoreBytes).toHaveBeenCalledTimes(1);
+    expect(mockStoreBytes).toHaveBeenCalledTimes(0);
   });
 
   it("should process multiple valid messages", async () => {
@@ -72,7 +77,10 @@ describe("handleMessages", () => {
     vi.setSystemTime(fakeDate);
 
     await handleMessages(
-      [validKafkaMessage, validKafkaMessage],
+      [
+        getValidKafkaMessage(validAuditEvent),
+        getValidKafkaMessage(validAuditEvent),
+      ],
       fileManager,
       genericLogger
     );
@@ -88,12 +96,55 @@ describe("handleMessages", () => {
     expect(mockStoreBytes).toHaveBeenCalledTimes(1);
   });
 
+  it("should process multiple messages with different dates and store each group correctly", async () => {
+    const mockStoreBytes = vi.fn().mockResolvedValue("mocked-s3-key");
+    fileManager.storeBytes = mockStoreBytes;
+
+    const fakeNow = new Date("2025-03-20T09:00:00");
+    vi.useFakeTimers();
+    vi.setSystemTime(fakeNow);
+
+    const dateStrings = [
+      "2025-03-17T10:00:00",
+      "2025-03-18T10:00:00",
+      "2025-03-19T10:00:00",
+    ];
+
+    const messages = dateStrings.map((dateStr) =>
+      getValidKafkaMessage({
+        ...validAuditEvent,
+        timestamp: new Date(dateStr).getTime(),
+      })
+    );
+
+    await handleMessages(messages, fileManager, genericLogger);
+
+    expect(mockStoreBytes).toHaveBeenCalledTimes(3);
+
+    dateStrings.forEach((dateStr, index) => {
+      const date = new Date(dateStr);
+      const year = date.getUTCFullYear();
+      const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+      const day = String(date.getUTCDate()).padStart(2, "0");
+      const time = formatTimehhmmss(fakeNow);
+
+      const s3File = mockStoreBytes.mock.calls[index][0];
+      expect(s3File.path).toBe(`year=${year}/month=${month}/day=${day}`);
+      expect(s3File.name).toContain(`${year}${month}${day}_${time}_`);
+      expect(mockStoreBytes).toHaveBeenCalledWith(s3File, genericLogger);
+    });
+  });
+
   it("should throw genericInternalError if storeBytes fails", async () => {
     fileManager.storeBytes = vi
       .fn()
       .mockRejectedValue(new Error("mocked error"));
     await expect(
-      handleMessages([validKafkaMessage], fileManager, genericLogger)
+      handleMessages(
+        [getValidKafkaMessage(validAuditEvent)],
+        fileManager,
+        genericLogger
+      )
     ).rejects.toThrowError(/Write operation failed - mocked error/);
   });
 

--- a/packages/application-audit-archiver/test/utils.ts
+++ b/packages/application-audit-archiver/test/utils.ts
@@ -22,18 +22,20 @@ export const validAuditEvent: ApplicationAuditEvent = {
   nodeIp: "192.168.1.10",
   podName: "pod-1",
   uptimeSeconds: 3600,
-  timestamp: Date.now(),
+  timestamp: new Date("2025-03-18T12:34:56").getTime(),
   amazonTraceId: "trace-123",
 };
 
-export const validKafkaMessage: KafkaMessage = {
+export const getValidKafkaMessage = (
+  message: ApplicationAuditEvent
+): KafkaMessage => ({
   key: Buffer.from("key1"),
-  value: Buffer.from(JSON.stringify(validAuditEvent)),
+  value: Buffer.from(JSON.stringify(message)),
   timestamp: new Date().toISOString(),
   offset: "0",
   attributes: 0,
   headers: {},
-};
+});
 
 export const invalidAuditEvent = {
   correlationId: "corr-invalid",

--- a/packages/commons/src/utils/sqlQueryHelper.ts
+++ b/packages/commons/src/utils/sqlQueryHelper.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
  * @param schemaName - The target db schema name.
  * @param tableName - The staging and target table name.
  * @param stagingSuffix - A suffix appended to the table name to indicate the staging table.
- * @param column - The key to be used for the ON condition (e.g., "correlation_id").
+ * @param keyOn - The key to be used for the ON condition (e.g., "correlation_id").
  * @returns The generated MERGE SQL query as a string.
  */
 export function generateMergeQuery<T extends z.ZodRawShape>(
@@ -15,7 +15,7 @@ export function generateMergeQuery<T extends z.ZodRawShape>(
   schemaName: string,
   tableName: string,
   stagingSuffix: string,
-  column: keyof T
+  keyOn: keyof T
 ): string {
   const keys = Object.keys(tableSchema.shape);
 
@@ -27,7 +27,7 @@ export function generateMergeQuery<T extends z.ZodRawShape>(
   return `
       MERGE INTO ${schemaName}.${tableName}
       USING ${tableName}${stagingSuffix} AS source
-      ON ${schemaName}.${tableName}.${String(column)} = source.${String(column)}
+      ON ${schemaName}.${tableName}.${String(keyOn)} = source.${String(keyOn)}
       WHEN MATCHED THEN
         UPDATE SET
           ${updateSet}


### PR DESCRIPTION
## Description

This pull group application audits logs by date using their timestamps. For each batch, if the logs have different dates, they will be grouped accordingly and written to the correct destination bucket.

## Changes Made
- Updated `application-audit-archiver` package.