### PR TITLE
Fix auth server end_request handler

### DIFF
--- a/packages/application-audit-analytics-writer/test/utils.ts
+++ b/packages/application-audit-analytics-writer/test/utils.ts
@@ -130,7 +130,7 @@ export function getMockApplicationAudits<T>(
       {
         clientId: generateId(),
       },
-      applicationAuditService.AUDIT_SERVER
+      applicationAuditService.AUTH_SERVER
     )
   );
 

--- a/packages/models/src/applicationAudit.ts
+++ b/packages/models/src/applicationAudit.ts
@@ -12,7 +12,7 @@ export const ApplicationAuditPhase = z.enum([
 
 export const applicationAuditService = {
   BFF: "backend-for-frontend",
-  AUTH_SERVER: "auth-server",
+  AUTH_SERVER: "authorization-server",
 } as const;
 
 export const ApplicationAuditService = z.enum([

--- a/packages/models/src/applicationAudit.ts
+++ b/packages/models/src/applicationAudit.ts
@@ -12,12 +12,12 @@ export const ApplicationAuditPhase = z.enum([
 
 export const applicationAuditService = {
   BFF: "backend-for-frontend",
-  AUDIT_SERVER: "auth-server",
+  AUTH_SERVER: "auth-server",
 } as const;
 
 export const ApplicationAuditService = z.enum([
   applicationAuditService.BFF,
-  applicationAuditService.AUDIT_SERVER,
+  applicationAuditService.AUTH_SERVER,
 ]);
 
 export const applicationAuditEndppoint = {
@@ -62,7 +62,7 @@ export type ApplicationAuditEndRequest = z.infer<
 
 export const ApplicationAuditEndRequestAuthServer =
   ApplicationAuditEndRequest.omit({ userId: true }).extend({
-    service: z.literal(applicationAuditService.AUDIT_SERVER),
+    service: z.literal(applicationAuditService.AUTH_SERVER),
     clientId: z.string().optional(),
   });
 export type ApplicationAuditEndRequestAuthServer = z.infer<
@@ -107,6 +107,6 @@ export function isEndRequestAuthServer(
 ): data is ApplicationAuditEndRequestAuthServer {
   return (
     data.phase === applicationAuditPhase.END_REQUEST &&
-    data.service === applicationAuditService.AUDIT_SERVER
+    data.service === applicationAuditService.AUTH_SERVER
   );
 }


### PR DESCRIPTION
This PR fixes an issue related to the `end_request` application audit of `auth-server`. Those message have `service` set as `authorization-server` and not `auth-server`.