### PR TITLE
fix: enforce throw error schema validation to prevent silent SQS message deletion

### DIFF
--- a/packages/alb-logs-analytics-writer/src/services/albLogsAuditService.ts
+++ b/packages/alb-logs-analytics-writer/src/services/albLogsAuditService.ts
@@ -39,8 +39,7 @@ export const albLogsAuditServiceBuilder = (
         LoadBalancerLogSchema,
         parsedFileStream,
         config.batchSize,
-        s3key,
-        logger
+        s3key
       )) {
         const filteredBatch = batch.filter(
           (record) => record.user_agent !== EXCLUDED_USER_AGENT

--- a/packages/alb-logs-analytics-writer/test/albLogsAuditService.test.ts
+++ b/packages/alb-logs-analytics-writer/test/albLogsAuditService.test.ts
@@ -137,20 +137,21 @@ describe("ALB Logs Audit Service", () => {
       LoadBalancerLogArraySchema.safeParse(transformedLogs);
     expect(loadBalancerParsed.success).toBeTruthy();
   });
-  it("should skip invalid records but continue processing valid ones", async () => {
+  it("should throw an error when invalid records are present in the file", async () => {
     const s3Key = "logs/invalid.gz";
 
     vi.spyOn(fileManager, "get").mockResolvedValue(
       createValidGzipStream(invalidEntries)
     );
 
-    await expect(
-      service.handleMessage(s3Key, genericLogger)
-    ).resolves.not.toThrow();
+    await expect(service.handleMessage(s3Key, genericLogger)).rejects.toThrow(
+      "Invalid record for file"
+    );
 
-    expect(dbService.insertRecordsToStaging).toHaveBeenCalledTimes(1);
-    expect(dbService.mergeStagingToTarget).toHaveBeenCalled();
+    expect(dbService.insertRecordsToStaging).not.toHaveBeenCalled();
+    expect(dbService.mergeStagingToTarget).not.toHaveBeenCalled();
   });
+
   it("should process all the records if all the file is well formed", async () => {
     vi.spyOn(fileManager, "get").mockResolvedValue(
       createValidGzipStream(validLogEntries)
@@ -169,8 +170,7 @@ describe("ALB Logs Audit Service", () => {
       LoadBalancerLogSchema,
       parsedFileStream,
       2,
-      "s3key",
-      genericLogger
+      "s3key"
     )) {
       // eslint-disable-next-line functional/immutable-data
       batchesIteration.push(batch);
@@ -180,29 +180,33 @@ describe("ALB Logs Audit Service", () => {
     expect(totalRecordsProcessed).toBe(5);
     expect(batchesIteration.length).toBe(3); // with batch 2, it takes 3 iterations;
   });
-  it("should process only the correct entries", async () => {
+  it("should throw an error when invalid entries are encountered in the stream", async () => {
     vi.spyOn(fileManager, "get").mockResolvedValue(
-      createValidGzipStream(invalidEntries)
+      createValidGzipStream(invalidEntries) // Contains both valid and invalid records
     );
+
     const fileStream = (
       await fileManager.get(config.s3Bucket, "s3Key", genericLogger)
     ).pipe(createGunzip());
+
     const parsedFileStream = transformFileStream(fileStream);
 
-    // eslint-disable-next-line functional/no-let
-    let totalRecordsProcessed = 0;
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    const process = async () => {
+      // eslint-disable-next-line functional/no-let
+      let totalRecordsProcessed = 0;
 
-    for await (const batch of batchItems(
-      LoadBalancerLogSchema,
-      parsedFileStream,
-      2,
-      "s3key",
-      genericLogger
-    )) {
-      // eslint-disable-next-line functional/immutable-data
-      totalRecordsProcessed += batch.length;
-    }
+      for await (const batch of batchItems(
+        LoadBalancerLogSchema,
+        parsedFileStream,
+        2,
+        "s3key"
+      )) {
+        totalRecordsProcessed += batch.length;
+      }
 
-    expect(totalRecordsProcessed).toBe(2); // number of correct line on invalidEntries;
+      expect(totalRecordsProcessed).toBe(0);
+    };
+    await expect(process()).rejects.toThrow("Invalid record for file");
   });
 });

--- a/packages/commons/src/utils/batchHelper.ts
+++ b/packages/commons/src/utils/batchHelper.ts
@@ -1,5 +1,5 @@
+import { genericInternalError } from "pagopa-interop-kpi-models";
 import { ZodSchema } from "zod";
-import { Logger } from "../index.js";
 
 /**
  * Async generator that batches records from an asynchronous iterable.
@@ -19,8 +19,7 @@ export async function* batchItems<TSchema>(
   schema: ZodSchema<TSchema>,
   source: AsyncIterable<unknown>,
   batchSize: number,
-  fileName: string,
-  logger: Logger
+  fileName: string
 ): AsyncGenerator<TSchema[]> {
   // eslint-disable-next-line functional/no-let
   let batch: TSchema[] = [];
@@ -30,7 +29,7 @@ export async function* batchItems<TSchema>(
       // eslint-disable-next-line functional/immutable-data
       batch.push(result.data);
     } else {
-      logger.warn(
+      throw genericInternalError(
         `Invalid record for file: ${fileName}. Data: ${JSON.stringify(
           rawRecord
         )}. Details: ${JSON.stringify(result.error)}`

--- a/packages/jwt-audit-analytics-writer/src/services/jwtAuditService.ts
+++ b/packages/jwt-audit-analytics-writer/src/services/jwtAuditService.ts
@@ -34,8 +34,7 @@ export const jwtAuditServiceBuilder = (
           tokenAuditSchema,
           parsedFileStream,
           config.batchSize,
-          s3key,
-          logger
+          s3key
         )) {
           await dbService.insertRecordsToStaging(batch);
           totalRecordsProcessed += batch.length;

--- a/packages/jwt-audit-analytics-writer/test/jwtAuditService.test.ts
+++ b/packages/jwt-audit-analytics-writer/test/jwtAuditService.test.ts
@@ -103,34 +103,30 @@ describe("JWT Audit Service tests", () => {
       expect(dbService.cleanStaging).not.toHaveBeenCalled();
     });
 
-    it("should call the logger for each invalid record, return the correct number of batches executed, and process the correct total number of valid records", async () => {
+    it("should throw an error when invalid records are encountered", async () => {
       const validRecords = getMockJwtAudits(5);
       const invalidRecords = Array.from({ length: 3 }, () => ({}));
       const allRecords: unknown[] = [...validRecords, ...invalidRecords];
       const source: AsyncIterable<unknown> = Readable.from(allRecords);
 
-      const parsingRecordErrorSpy = vi.spyOn(genericLogger, "warn");
+      // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+      const process = async () => {
+        // eslint-disable-next-line functional/no-let
+        let totalRecordsProcessed = 0;
 
-      // eslint-disable-next-line functional/no-let
-      let totalRecordsProcessed = 0;
+        for await (const batch of batchItems(
+          tokenAuditSchema,
+          source,
+          2,
+          "s3key"
+        )) {
+          totalRecordsProcessed += batch.length;
+        }
 
-      const batchesIteration: unknown[][] = [];
+        expect(totalRecordsProcessed).toBe(0);
+      };
 
-      for await (const batch of batchItems(
-        tokenAuditSchema,
-        source,
-        2,
-        "s3key",
-        genericLogger
-      )) {
-        // eslint-disable-next-line functional/immutable-data
-        batchesIteration.push(batch);
-        totalRecordsProcessed += batch.length;
-      }
-
-      expect(totalRecordsProcessed).toBe(5);
-      expect(batchesIteration.length).toBe(3);
-      expect(parsingRecordErrorSpy).toHaveBeenCalledTimes(3);
+      await expect(process()).rejects.toThrow("Invalid record for file");
     });
   });
 });

--- a/packages/jwt-audit-analytics-writer/test/utils.ts
+++ b/packages/jwt-audit-analytics-writer/test/utils.ts
@@ -67,7 +67,7 @@ export function getMockJwtAudits(n: number): GeneratedTokenAuditDetails[] {
 }
 
 export const getMockJwtAudit = (): GeneratedTokenAuditDetails => {
-  const correlationId = generateId();
+  const correlationId = undefined;
   const eserviceId = generateId<EServiceId>();
   const descriptorId = generateId<DescriptorId>();
   const agreementId = generateId<AgreementId>();

--- a/packages/jwt-audit-analytics-writer/test/utils.ts
+++ b/packages/jwt-audit-analytics-writer/test/utils.ts
@@ -67,7 +67,7 @@ export function getMockJwtAudits(n: number): GeneratedTokenAuditDetails[] {
 }
 
 export const getMockJwtAudit = (): GeneratedTokenAuditDetails => {
-  const correlationId = undefined;
+  const correlationId = generateId();
   const eserviceId = generateId<EServiceId>();
   const descriptorId = generateId<DescriptorId>();
   const agreementId = generateId<AgreementId>();


### PR DESCRIPTION
This PR updates the batchItems logic to throw an error on invalid records instead of logging and continuing.

The goal is to prevent deletion of SQS messages containing invalid data. This change causes the consumer to exit if invalid records are encountered.

Tests that previously assumed partial success have been updated to expect exceptions.

Note: This makes the consumer stricter. If invalid messages are common, it may cause repeated restarts. 