### PR TITLE
Jwt Audit: Implement batch deduplication for generated tokens

### DIFF
--- a/packages/jwt-audit-analytics-writer/src/services/jwtAuditService.ts
+++ b/packages/jwt-audit-analytics-writer/src/services/jwtAuditService.ts
@@ -7,6 +7,7 @@ import {
   GeneratedTokenAuditDetails,
   tokenAuditSchema,
 } from "../model/domain/models.js";
+import { deduplicateJwtIdRecords } from "../utilities/deduplicateRecords.js";
 import { DBService } from "./dbService.js";
 
 export const jwtAuditServiceBuilder = (
@@ -16,7 +17,6 @@ export const jwtAuditServiceBuilder = (
   async handleMessages(s3keys: string[], logger: Logger): Promise<void> {
     let totalRecordsProcessed: number = 0;
     let currentFile: string = "";
-
     try {
       for (const s3key of s3keys) {
         currentFile = s3key;
@@ -36,8 +36,9 @@ export const jwtAuditServiceBuilder = (
           config.batchSize,
           s3key
         )) {
-          await dbService.insertRecordsToStaging(batch);
-          totalRecordsProcessed += batch.length;
+          const uniqueBatch = deduplicateJwtIdRecords(batch, logger);
+          await dbService.insertRecordsToStaging(uniqueBatch);
+          totalRecordsProcessed += uniqueBatch.length;
         }
 
         logger.debug(

--- a/packages/jwt-audit-analytics-writer/src/utilities/deduplicateRecords.ts
+++ b/packages/jwt-audit-analytics-writer/src/utilities/deduplicateRecords.ts
@@ -1,3 +1,5 @@
+/* eslint-disable functional/immutable-data */
+
 import { Logger } from "pagopa-interop-kpi-commons";
 import { GeneratedTokenAuditDetails } from "../model/domain/models.js";
 
@@ -14,31 +16,28 @@ export function deduplicateJwtIdRecords(
   batch: GeneratedTokenAuditDetails[],
   logger: Logger
 ): GeneratedTokenAuditDetails[] {
-  const jwtIdCounts = new Map<string, number>();
-  const duplicateJwtIds = new Set<string>();
+  const uniqueJwtIds = new Set<string>();
+  const uniqueRecords: GeneratedTokenAuditDetails[] = [];
+  const removedDuplicates: string[] = [];
 
-  batch.forEach((record) => {
-    const jwtId = record.jwtId;
-    jwtIdCounts.set(jwtId, (jwtIdCounts.get(jwtId) || 0) + 1);
-  });
-
-  const uniqueRecords = batch.filter(
-    (record) => jwtIdCounts.get(record.jwtId) === 1
-  );
-  jwtIdCounts.forEach((count, jwtId) => {
-    if (count > 1) {
-      duplicateJwtIds.add(jwtId);
+  for (const record of batch) {
+    if (!uniqueJwtIds.has(record.jwtId)) {
+      uniqueJwtIds.add(record.jwtId);
+      uniqueRecords.push(record);
+    } else {
+      removedDuplicates.push(record.jwtId);
     }
-  });
+  }
 
-  if (uniqueRecords.length < batch.length) {
+  if (removedDuplicates.length > 0) {
     logger.warn(
       `Detected and removed ${
-        batch.length - uniqueRecords.length
-      } duplicate records in the batch. jwt_id: [${Array.from(
-        duplicateJwtIds
-      ).join(", ")}]`
+        removedDuplicates.length
+      } duplicate records in the batch. jwt_id: [${[
+        ...new Set(removedDuplicates),
+      ].join(", ")}]`
     );
   }
+
   return uniqueRecords;
 }

--- a/packages/jwt-audit-analytics-writer/src/utilities/deduplicateRecords.ts
+++ b/packages/jwt-audit-analytics-writer/src/utilities/deduplicateRecords.ts
@@ -1,0 +1,44 @@
+import { Logger } from "pagopa-interop-kpi-commons";
+import { GeneratedTokenAuditDetails } from "../model/domain/models.js";
+
+/**
+ * Deduplicates an array of GeneratedTokenAuditDetails records based on their `jwtId`.
+ * If a `jwtId` appears more than once in the batch, all occurrences of that `jwtId` are removed.
+ * Records with unique `jwtId`s are retained.
+ *
+ * @param batch - The array of `GeneratedTokenAuditDetails` records to deduplicate.
+ * @param logger - An instance of a logger to log warnings about removed duplicates.
+ * @returns A new array containing only the unique `GeneratedTokenAuditDetails` records.
+ */
+export function deduplicateJwtIdRecords(
+  batch: GeneratedTokenAuditDetails[],
+  logger: Logger
+): GeneratedTokenAuditDetails[] {
+  const jwtIdCounts = new Map<string, number>();
+  const duplicateJwtIds = new Set<string>();
+
+  batch.forEach((record) => {
+    const jwtId = record.jwtId;
+    jwtIdCounts.set(jwtId, (jwtIdCounts.get(jwtId) || 0) + 1);
+  });
+
+  const uniqueRecords = batch.filter(
+    (record) => jwtIdCounts.get(record.jwtId) === 1
+  );
+  jwtIdCounts.forEach((count, jwtId) => {
+    if (count > 1) {
+      duplicateJwtIds.add(jwtId);
+    }
+  });
+
+  if (uniqueRecords.length < batch.length) {
+    logger.warn(
+      `Detected and removed ${
+        batch.length - uniqueRecords.length
+      } duplicate records in the batch. jwt_id: [${Array.from(
+        duplicateJwtIds
+      ).join(", ")}]`
+    );
+  }
+  return uniqueRecords;
+}

--- a/packages/jwt-audit-analytics-writer/test/jwtAuditService.test.ts
+++ b/packages/jwt-audit-analytics-writer/test/jwtAuditService.test.ts
@@ -101,7 +101,7 @@ describe("JWT Audit Service tests", () => {
         conn,
         JwtDbTable.generated_token
       );
-      expect(generatedTokenCount).toBe(6);
+      expect(generatedTokenCount).toBe(9);
     });
 
     it("should not call any dbService operations when there are no records", async () => {

--- a/packages/jwt-audit-analytics-writer/test/jwtAuditService.test.ts
+++ b/packages/jwt-audit-analytics-writer/test/jwtAuditService.test.ts
@@ -26,6 +26,7 @@ import {
   setupDbService,
   truncateTables,
   writeJwtAuditNdjson,
+  getMockJwtAuditWithDuplicates,
 } from "./utils.js";
 
 describe("JWT Audit Service tests", () => {
@@ -83,6 +84,24 @@ describe("JWT Audit Service tests", () => {
         JwtDbTable.generated_token
       );
       expect(generatedTokenCount).toBe(10);
+    });
+    it("should read the ndjson file from s3 and persist its data with deduplication to the database successfully", async () => {
+      const records: GeneratedTokenAuditDetails[] =
+        getMockJwtAuditWithDuplicates();
+
+      const { fullPathName } = await writeJwtAuditNdjson(
+        records,
+        fileManager,
+        genericLogger
+      );
+
+      await jwtAuditService.handleMessages([fullPathName], genericLogger);
+
+      const generatedTokenCount = await getTargetTableCount(
+        conn,
+        JwtDbTable.generated_token
+      );
+      expect(generatedTokenCount).toBe(6);
     });
 
     it("should not call any dbService operations when there are no records", async () => {

--- a/packages/jwt-audit-analytics-writer/test/utils.ts
+++ b/packages/jwt-audit-analytics-writer/test/utils.ts
@@ -1,3 +1,5 @@
+/* eslint-disable functional/immutable-data */
+
 import { setupTestContainersVitest } from "pagopa-interop-kpi-commons-test";
 import {
   AgreementId,
@@ -64,6 +66,39 @@ export const jwtAuditService = jwtAuditServiceBuilder(dbService, fileManager);
 
 export function getMockJwtAudits(n: number): GeneratedTokenAuditDetails[] {
   return Array.from({ length: n }, () => getMockJwtAudit());
+}
+
+export function getMockJwtAuditWithDuplicates(): GeneratedTokenAuditDetails[] {
+  const audits: GeneratedTokenAuditDetails[] = [];
+
+  const baseAudits = getMockJwtAudits(5);
+
+  audits.push(...baseAudits);
+
+  const firstAuditJwtId = baseAudits[0].jwtId;
+  const duplicate1 = getMockJwtAudit();
+  duplicate1.jwtId = firstAuditJwtId;
+  audits.push(duplicate1);
+
+  const secondAuditJwtId = baseAudits[1].jwtId;
+  const duplicate2 = getMockJwtAudit();
+  duplicate2.jwtId = secondAuditJwtId;
+  audits.push(duplicate2);
+
+  const newUniqueAudit = getMockJwtAudit();
+  audits.push(newUniqueAudit);
+
+  const duplicate3 = getMockJwtAudit();
+  duplicate3.jwtId = newUniqueAudit.jwtId;
+  audits.push(duplicate3);
+
+  const duplicate4 = getMockJwtAudit();
+  duplicate4.jwtId = newUniqueAudit.jwtId;
+  audits.push(duplicate4);
+
+  audits.push(...getMockJwtAudits(3));
+
+  return audits;
 }
 
 export const getMockJwtAudit = (): GeneratedTokenAuditDetails => {


### PR DESCRIPTION
- This PR introduces a deduplication function for jwt batches.

- It ensures that any record with a non-unique `jwtId` is removed from the batch, preventing duplicate data from being processed and written to the target table. 