### PR TITLE
fix: Implemented deduplication stage jwt-audit-analytics-writer

### DIFF
--- a/packages/commons/src/db/setupDbservice.ts
+++ b/packages/commons/src/db/setupDbservice.ts
@@ -18,6 +18,7 @@ export function setupDbServiceBuilder(
           tableNames.map((tableName) => {
             const query = `
               CREATE TEMPORARY TABLE IF NOT EXISTS ${tableName}${config.mergeTableSuffix} (
+                _seq BIGINT GENERATED ALWAYS AS IDENTITY,
                 LIKE ${config.dbSchemaName}.${tableName}
               );
             `;

--- a/packages/commons/src/utils/sqlQueryHelper.ts
+++ b/packages/commons/src/utils/sqlQueryHelper.ts
@@ -47,16 +47,16 @@ export function generateMergeQuery<T extends z.ZodRawShape>(
 /**
  * Generates a deduplication DELETE query for a given staging table.
  *
- * @param tableName - The staging and target table name.
+ * @param stagingTableName - The staging table name.
  * @param partitionKey - Column name to PARTITION BY
  * @returns The deduplication SQL query as a string.
  */
 export function generateDeduplicationQuery(
-  tableName: string,
+  stagingTableName: string,
   partitionKey: string
 ): string {
   return `
-    DELETE FROM ${tableName}
+    DELETE FROM ${stagingTableName}
     USING (
       SELECT _seq FROM (
         SELECT _seq,
@@ -64,10 +64,10 @@ export function generateDeduplicationQuery(
                 PARTITION BY ${partitionKey}
                 ORDER BY issued_at DESC, _seq
               ) AS rn
-        FROM ${tableName}
+        FROM ${stagingTableName}
       ) sub
       WHERE rn > 1
     ) d
-    WHERE ${tableName}._seq = d._seq;
+    WHERE ${stagingTableName}._seq = d._seq;
   `;
 }

--- a/packages/commons/src/utils/sqlQueryHelper.ts
+++ b/packages/commons/src/utils/sqlQueryHelper.ts
@@ -43,3 +43,31 @@ export function generateMergeQuery<T extends z.ZodRawShape>(
         VALUES (${values});
     `;
 }
+
+/**
+ * Generates a deduplication DELETE query for a given staging table.
+ *
+ * @param tableName - The staging and target table name.
+ * @param partitionKey - Column name to PARTITION BY
+ * @returns The deduplication SQL query as a string.
+ */
+export function generateDeduplicationQuery(
+  tableName: string,
+  partitionKey: string
+): string {
+  return `
+    DELETE FROM ${tableName}
+    USING (
+      SELECT _seq FROM (
+        SELECT _seq,
+              ROW_NUMBER() OVER (
+                PARTITION BY ${partitionKey}
+                ORDER BY issued_at DESC, _seq
+              ) AS rn
+        FROM ${tableName}
+      ) sub
+      WHERE rn > 1
+    ) d
+    WHERE ${tableName}._seq = d._seq;
+  `;
+}

--- a/packages/jwt-audit-analytics-writer/src/repositories/clientAssertion.repository.ts
+++ b/packages/jwt-audit-analytics-writer/src/repositories/clientAssertion.repository.ts
@@ -4,6 +4,7 @@ import {
   IMain,
   ITask,
   buildColumnSet,
+  generateDeduplicationQuery,
   generateMergeQuery,
 } from "pagopa-interop-kpi-commons";
 import { genericInternalError, JwtDbTable } from "pagopa-interop-kpi-models";
@@ -65,6 +66,20 @@ export function clientAssertionRepository(conn: DBConnection) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error merging staging to target ${clientAssertionTable} table: ${error}`
+        );
+      }
+    },
+
+    async deduplicate(t: ITask<unknown>): Promise<void> {
+      try {
+        const deduplicationQuery = generateDeduplicationQuery(
+          clientAssertionStagingTable,
+          "generated_token_jwt_id"
+        );
+        await t.none(deduplicationQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error deduplicating staging ${clientAssertionStagingTable} table: ${error}`
         );
       }
     },

--- a/packages/jwt-audit-analytics-writer/src/repositories/generatedToken.repository.ts
+++ b/packages/jwt-audit-analytics-writer/src/repositories/generatedToken.repository.ts
@@ -4,6 +4,7 @@ import {
   IMain,
   ITask,
   buildColumnSet,
+  generateDeduplicationQuery,
   generateMergeQuery,
 } from "pagopa-interop-kpi-commons";
 import { genericInternalError, JwtDbTable } from "pagopa-interop-kpi-models";
@@ -73,6 +74,20 @@ export function generatedTokenRepository(conn: DBConnection) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error merging staging to target ${generatedTokenTable} table: ${error}`
+        );
+      }
+    },
+
+    async deduplicate(t: ITask<unknown>): Promise<void> {
+      try {
+        const deduplicationQuery = generateDeduplicationQuery(
+          tokenAuditStagingTable,
+          "jwt_id"
+        );
+        await t.none(deduplicationQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error deduplicating staging ${tokenAuditStagingTable} table: ${error}`
         );
       }
     },

--- a/packages/jwt-audit-analytics-writer/src/services/dbService.ts
+++ b/packages/jwt-audit-analytics-writer/src/services/dbService.ts
@@ -26,6 +26,13 @@ export function dbServiceBuilder(
       });
     },
 
+    async deduplicateStaging(): Promise<void> {
+      await db.conn.tx(async (t) => {
+        await generatedTokenRepo(db.conn).deduplicate(t);
+        await clientAssertionRepo(db.conn).deduplicate(t);
+      });
+    },
+
     async cleanStaging(): Promise<void> {
       await generatedTokenRepo(db.conn).clean();
       await clientAssertionRepo(db.conn).clean();

--- a/packages/jwt-audit-analytics-writer/src/services/jwtAuditService.ts
+++ b/packages/jwt-audit-analytics-writer/src/services/jwtAuditService.ts
@@ -7,7 +7,6 @@ import {
   GeneratedTokenAuditDetails,
   tokenAuditSchema,
 } from "../model/domain/models.js";
-import { deduplicateJwtIdRecords } from "../utilities/deduplicateRecords.js";
 import { DBService } from "./dbService.js";
 
 export const jwtAuditServiceBuilder = (
@@ -36,9 +35,8 @@ export const jwtAuditServiceBuilder = (
           config.batchSize,
           s3key
         )) {
-          const uniqueBatch = deduplicateJwtIdRecords(batch, logger);
-          await dbService.insertRecordsToStaging(uniqueBatch);
-          totalRecordsProcessed += uniqueBatch.length;
+          await dbService.insertRecordsToStaging(batch);
+          totalRecordsProcessed += batch.length;
         }
 
         logger.debug(
@@ -57,6 +55,11 @@ export const jwtAuditServiceBuilder = (
       logger.info(
         `Staging insertion completed with ${totalRecordsProcessed} records processed.`
       );
+
+      const deduplicateStartTime = Date.now();
+      await dbService.deduplicateStaging();
+
+      logger.info(`Staging data deduplicated`, deduplicateStartTime);
 
       const mergeStartTime = Date.now();
       await dbService.mergeStagingToTarget();

--- a/packages/jwt-audit-analytics-writer/test/jwtAuditService.test.ts
+++ b/packages/jwt-audit-analytics-writer/test/jwtAuditService.test.ts
@@ -87,7 +87,7 @@ describe("JWT Audit Service tests", () => {
     });
     it("should read the ndjson file from s3 and persist its data with deduplication to the database successfully", async () => {
       const records: GeneratedTokenAuditDetails[] =
-        getMockJwtAuditWithDuplicates();
+        getMockJwtAuditWithDuplicates(900, 100);
 
       const { fullPathName } = await writeJwtAuditNdjson(
         records,
@@ -101,7 +101,7 @@ describe("JWT Audit Service tests", () => {
         conn,
         JwtDbTable.generated_token
       );
-      expect(generatedTokenCount).toBe(9);
+      expect(generatedTokenCount).toBe(900);
     });
 
     it("should not call any dbService operations when there are no records", async () => {

--- a/packages/jwt-audit-analytics-writer/test/utils.ts
+++ b/packages/jwt-audit-analytics-writer/test/utils.ts
@@ -76,7 +76,7 @@ export function getMockJwtAuditWithDuplicates(
 
   const baseAudits = getMockJwtAudits(records);
   audits.push(...baseAudits);
-
+  // eslint-disable-next-line functional/no-let
   for (let i = 0; i < duplicates; i++) {
     audits.push(baseAudits[i]);
   }

--- a/packages/jwt-audit-analytics-writer/test/utils.ts
+++ b/packages/jwt-audit-analytics-writer/test/utils.ts
@@ -68,36 +68,18 @@ export function getMockJwtAudits(n: number): GeneratedTokenAuditDetails[] {
   return Array.from({ length: n }, () => getMockJwtAudit());
 }
 
-export function getMockJwtAuditWithDuplicates(): GeneratedTokenAuditDetails[] {
+export function getMockJwtAuditWithDuplicates(
+  records: number,
+  duplicates: number
+): GeneratedTokenAuditDetails[] {
   const audits: GeneratedTokenAuditDetails[] = [];
 
-  const baseAudits = getMockJwtAudits(5);
-
+  const baseAudits = getMockJwtAudits(records);
   audits.push(...baseAudits);
 
-  const firstAuditJwtId = baseAudits[0].jwtId;
-  const duplicate1 = getMockJwtAudit();
-  duplicate1.jwtId = firstAuditJwtId;
-  audits.push(duplicate1);
-
-  const secondAuditJwtId = baseAudits[1].jwtId;
-  const duplicate2 = getMockJwtAudit();
-  duplicate2.jwtId = secondAuditJwtId;
-  audits.push(duplicate2);
-
-  const newUniqueAudit = getMockJwtAudit();
-  audits.push(newUniqueAudit);
-
-  const duplicate3 = getMockJwtAudit();
-  duplicate3.jwtId = newUniqueAudit.jwtId;
-  audits.push(duplicate3);
-
-  const duplicate4 = getMockJwtAudit();
-  duplicate4.jwtId = newUniqueAudit.jwtId;
-  audits.push(duplicate4);
-
-  audits.push(...getMockJwtAudits(3));
-
+  for (let i = 0; i < duplicates; i++) {
+    audits.push(baseAudits[i]);
+  }
   return audits;
 }
 


### PR DESCRIPTION
This PR introduces a deduplication stage in the` jwt-audit-analytics-writer` workflow to ensure that duplicate records are removed from the staging tables before merging into the target tables.