### PR TITLE
feature(PIN-9681): add staging deduplication for application audit

### DIFF
--- a/packages/application-audit-analytics-writer/src/handlers/batchHandler.ts
+++ b/packages/application-audit-analytics-writer/src/handlers/batchHandler.ts
@@ -22,6 +22,7 @@ export async function processBatch<
   TRepository extends {
     insertToStaging: (messages: TSchema[]) => Promise<void>;
     copyFromS3ToStaging: (s3ObjectKey: string) => Promise<void>;
+    deduplicateStaging: () => Promise<void>;
     mergeStagingToTarget: () => Promise<void>;
     cleanStaging: () => Promise<void>;
   }
@@ -56,6 +57,13 @@ export async function processBatch<
     if (ingestionState.totalRecordsProcessed === 0) {
       return;
     }
+
+    const batchDeduplicateStartTime = Date.now();
+    await repository.deduplicateStaging();
+    logger.info(
+      `Staging data deduplicated for ${ingestionState.currentTable} batch.`,
+      batchDeduplicateStartTime
+    );
 
     const batchMergeStartTime = Date.now();
     await repository.mergeStagingToTarget();

--- a/packages/application-audit-analytics-writer/src/repositories/beginRequest.repository.ts
+++ b/packages/application-audit-analytics-writer/src/repositories/beginRequest.repository.ts
@@ -3,6 +3,7 @@ import {
   DBConnection,
   IMain,
   buildColumnSet,
+  generateDeduplicationQuery,
   generateMergeQuery,
 } from "pagopa-interop-kpi-commons";
 import {
@@ -95,6 +96,21 @@ export function beginRequestRepository(conn: DBConnection, pgp: IMain) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error merging staging to target ${beginRequestTable} table: ${error}`
+        );
+      }
+    },
+
+    async deduplicateStaging(): Promise<void> {
+      try {
+        const deduplicationQuery = generateDeduplicationQuery(
+          beginRequestStagingTable,
+          "span_id",
+          "timestamp"
+        );
+        await conn.none(deduplicationQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error deduplicating staging ${beginRequestStagingTable} table: ${error}`
         );
       }
     },

--- a/packages/application-audit-analytics-writer/src/repositories/endRequest.repository.ts
+++ b/packages/application-audit-analytics-writer/src/repositories/endRequest.repository.ts
@@ -3,6 +3,7 @@ import {
   DBConnection,
   IMain,
   buildColumnSet,
+  generateDeduplicationQuery,
   generateMergeQuery,
 } from "pagopa-interop-kpi-commons";
 import {
@@ -96,6 +97,21 @@ export function endRequestRepository(conn: DBConnection, pgp: IMain) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error merging staging to target ${endRequestTable} table: ${error}`
+        );
+      }
+    },
+
+    async deduplicateStaging(): Promise<void> {
+      try {
+        const deduplicationQuery = generateDeduplicationQuery(
+          endRequestStagingTable,
+          "span_id",
+          "timestamp"
+        );
+        await conn.none(deduplicationQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error deduplicating staging ${endRequestStagingTable} table: ${error}`
         );
       }
     },

--- a/packages/application-audit-analytics-writer/src/repositories/endRequestAuthServer.repository.ts
+++ b/packages/application-audit-analytics-writer/src/repositories/endRequestAuthServer.repository.ts
@@ -3,6 +3,7 @@ import {
   DBConnection,
   IMain,
   buildColumnSet,
+  generateDeduplicationQuery,
   generateMergeQuery,
 } from "pagopa-interop-kpi-commons";
 import {
@@ -103,6 +104,21 @@ export function endRequestAuthServerRepository(conn: DBConnection, pgp: IMain) {
       } catch (error: unknown) {
         throw genericInternalError(
           `Error merging staging to target ${endRequestAuthServerTable} table: ${error}`
+        );
+      }
+    },
+
+    async deduplicateStaging(): Promise<void> {
+      try {
+        const deduplicationQuery = generateDeduplicationQuery(
+          endRequestAuthServerStagingTable,
+          "span_id",
+          "timestamp"
+        );
+        await conn.none(deduplicationQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error deduplicating staging ${endRequestAuthServerStagingTable} table: ${error}`
         );
       }
     },

--- a/packages/application-audit-analytics-writer/src/repositories/endRequestSessionTokenExchange.repository.ts
+++ b/packages/application-audit-analytics-writer/src/repositories/endRequestSessionTokenExchange.repository.ts
@@ -3,6 +3,7 @@ import {
   DBConnection,
   IMain,
   buildColumnSet,
+  generateDeduplicationQuery,
   generateMergeQuery,
 } from "pagopa-interop-kpi-commons";
 import {
@@ -106,6 +107,21 @@ export function endRequestSessionTokenExchangeRepository(
       } catch (error: unknown) {
         throw genericInternalError(
           `Error merging staging to target ${endRequestSessionTokenExchangeTable} table: ${error}`
+        );
+      }
+    },
+
+    async deduplicateStaging(): Promise<void> {
+      try {
+        const deduplicationQuery = generateDeduplicationQuery(
+          endRequestSessionTokenExchangeStagingTable,
+          "span_id",
+          "timestamp"
+        );
+        await conn.none(deduplicationQuery);
+      } catch (error: unknown) {
+        throw genericInternalError(
+          `Error deduplicating staging ${endRequestSessionTokenExchangeStagingTable} table: ${error}`
         );
       }
     },

--- a/packages/commons/src/utils/sqlQueryHelper.ts
+++ b/packages/commons/src/utils/sqlQueryHelper.ts
@@ -82,7 +82,8 @@ export function generateMergeQuery<T extends z.ZodRawShape>(
  */
 export function generateDeduplicationQuery(
   stagingTableName: string,
-  partitionKey: string
+  partitionKey: string,
+  orderByColumn: string
 ): string {
   return `
     DELETE FROM ${stagingTableName}
@@ -91,7 +92,7 @@ export function generateDeduplicationQuery(
         SELECT _seq,
               ROW_NUMBER() OVER (
                 PARTITION BY ${partitionKey}
-                ORDER BY issued_at DESC, _seq
+                ORDER BY ${orderByColumn} DESC, _seq
               ) AS rn
         FROM ${stagingTableName}
       ) sub

--- a/packages/jwt-audit-analytics-writer/src/repositories/clientAssertion.repository.ts
+++ b/packages/jwt-audit-analytics-writer/src/repositories/clientAssertion.repository.ts
@@ -118,7 +118,8 @@ export function clientAssertionRepository(conn: DBConnection) {
       try {
         const deduplicationQuery = generateDeduplicationQuery(
           clientAssertionStagingTable,
-          "generated_token_jwt_id"
+          "generated_token_jwt_id",
+          "issued_at"
         );
         await t.none(deduplicationQuery);
       } catch (error: unknown) {

--- a/packages/jwt-audit-analytics-writer/src/repositories/generatedToken.repository.ts
+++ b/packages/jwt-audit-analytics-writer/src/repositories/generatedToken.repository.ts
@@ -117,7 +117,8 @@ export function generatedTokenRepository(conn: DBConnection) {
       try {
         const deduplicationQuery = generateDeduplicationQuery(
           tokenAuditStagingTable,
-          "jwt_id"
+          "jwt_id",
+          "issued_at"
         );
         await t.none(deduplicationQuery);
       } catch (error: unknown) {


### PR DESCRIPTION
## Jira Issue
[PIN-9681](https://pagopa.atlassian.net/browse/PIN-9681)

## Context/Why
- Application audit staging can contain duplicates (same span_id)
- Add explicit staging deduplication to avoid duplicate inserts in target

## Services Impacted
- jwt-audit-analytics-write
- application-audit-analytics-writer
- commons

## Key Changes
 - Add `orderByColumn` parameter to `generateDeduplicationQuery`
 - Aligned `generateDeduplicationQuery` to jwt-audit-analytics-write passing `orderByColumn`
 -  Added deduplicate to application audit staging before merge using `timestamp`

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard

[PIN-9681]: https://pagopa.atlassian.net/browse/PIN-9681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ