### PR TITLE
fix(PIN-10094): make token audit typ optional jwt-audit-analytics-writer

### DIFF
--- a/packages/jwt-audit-analytics-writer/src/model/db.ts
+++ b/packages/jwt-audit-analytics-writer/src/model/db.ts
@@ -46,7 +46,7 @@ export const GeneratedTokenSchema = z.object({
   issuer: z.string(),
   client_assertion_jwt_id: z.string(),
   origin_file_reference: z.string().nullish(),
-  typ: z.string(),
+  typ: z.string().optional(),
   cnf_jkt: z.string().optional(),
   digest_alg: z.string().optional(),
   digest_val: z.string().optional(),

--- a/packages/jwt-audit-analytics-writer/src/model/domain/models.ts
+++ b/packages/jwt-audit-analytics-writer/src/model/domain/models.ts
@@ -88,7 +88,7 @@ export const GeneratedTokenAuditDetails = z
     purposeVersionId: PurposeVersionId,
     algorithm: z.string(),
     keyId: z.string(),
-    typ: z.string(),
+    typ: z.string().optional(),
     audience: z.string(),
     subject: z.string(),
     notBefore: z.number(),


### PR DESCRIPTION
## Jira Issue
[PIN-10094](https://pagopa.atlassian.net/browse/PIN-10094)

## Context/Why
- `typ` was introduced by the token audit extra claims feature, but the DB column is nullable, so the parser should accept records where it is absent.

## Services Impacted
- jwt-audit-analytics-writer

## Key Changes
- Make generated token audit `typ` optional in the domain schema.
- Align generated token DB schema validation with nullable `typ`.

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard

[PIN-10094]: https://pagopa.atlassian.net/browse/PIN-10094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ